### PR TITLE
Updated Map class to use proper iteration

### DIFF
--- a/src/net/scratchforfun/gamedev/world/Map.java
+++ b/src/net/scratchforfun/gamedev/world/Map.java
@@ -5,16 +5,15 @@ import net.scratchforfun.gamedev.entity.Entity;
 import net.scratchforfun.gamedev.reference.References;
 
 import java.awt.*;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.*;
 
 /**
  * Created by Scratch on 9/24/2014.
  */
 public class Map {
 
-    List<Chunk> loadedChunks = new CopyOnWriteArrayList<Chunk>();
-    List<Entity> loadedEntities = new CopyOnWriteArrayList<Entity>();
+    List<Chunk> loadedChunks = new ArrayList<Chunk>();
+    List<Entity> loadedEntities = new ArrayList<Entity>();
 
     public Map(){
         checkChunks();
@@ -59,9 +58,10 @@ public class Map {
     }
 
     private void unloadChunks(int player_chunk_x, int player_chunk_y){
-        for(Chunk chunk : loadedChunks){
+        for(Iterator<Chunk> iterator = loadedChunks.iterator(); iterator.hasNext();){
+            Chunk chunk = iterator.next();
             if(chunk.CHUNK_X > player_chunk_x+(References.CHUNK_AMOUNT_X-1)/2 || chunk.CHUNK_X < player_chunk_x-(References.CHUNK_AMOUNT_X-1)/2 || chunk.CHUNK_Y > player_chunk_y+(References.CHUNK_AMOUNT_Y-1)/2 || chunk.CHUNK_Y < player_chunk_y-(References.CHUNK_AMOUNT_Y-1)/2)
-                loadedChunks.remove(chunk);
+                iterator.remove();
         }
     }
 


### PR DESCRIPTION
There is no reason to use a `CopyOnWriteArrayList` - it is a lot slower and less efficient. Simply using proper iteration stops CME's from occurring and is much better practice.

In the case where thread safety is also needed, `Collections.synchronizedList(List<T>)` is a much better alternative for this list as it mutates often.
